### PR TITLE
Feature/block index

### DIFF
--- a/docs/guide/templating.md
+++ b/docs/guide/templating.md
@@ -46,6 +46,9 @@ _string_ - The classnames that you should apply to **each** post/grid item.
 ### block_attributes
 _array_ - The raw attributes saved to the database for the block instance. If you have added `customControls` to your config, the values of those will be included here.
 
+### block_index
+_integer_ - The index of the current block. `0` for the first Solaplexus block on the page `1` for the second and so on.
+
 ### config
 _array_ - The Solarplexus config for the block type of the block instance
 

--- a/includes/class-solarplexus-helpers.php
+++ b/includes/class-solarplexus-helpers.php
@@ -11,6 +11,8 @@
 class Solarplexus_Helpers {
   // Used to keep track of rendered posts to avoid duplicates
   private static $rendered_post_ids = [];
+  // Used to know which block we are in
+  private static $block_index = 0;
 
   public static function retrieve_block_configs() {
     // Allow config via PHP
@@ -245,11 +247,15 @@ class Solarplexus_Helpers {
      */
     $posts = apply_filters( 'splx_posts', $posts, $block_config, $block_attributes, $pagination );
 
+    $block_index = self::$block_index;
+    self::$block_index++;
+
     return [
       'query' => $query->query,
       'posts' => $posts,
       'pagination' => $pagination,
       'block_attributes' => $block_attributes,
+      'block_index' => $block_index,
       'classes_grid' => apply_filters( 'splx_grid_classes', self::block_classes($classes_grid), $block_config, $block_attributes ),
       'classes_item' => apply_filters( 'splx_item_classes', self::block_classes($classes_item), $block_config, $block_attributes ),
       'config' => $block_config


### PR DESCRIPTION
Closes #67 

$block_index is added to block args to enable plugin users to know which block they are in (e.g. `$block_index == 0` means that this is the first Solarplexus block on the page).