### PR TITLE
Prevent plugin script dependencies being loaded in frontend by default

### DIFF
--- a/admin/class-solarplexus-admin.php
+++ b/admin/class-solarplexus-admin.php
@@ -146,10 +146,14 @@ class Solarplexus_Admin {
 	}
 
 	public function register_block() {
+		$enable_default_style = apply_filters(
+			'splx_enable_default_style',
+			false
+		);
 		$block_style_handle = 'solarplexus-style';
 		$theme_config_path = Solarplexus_Helpers::get_theme_config_path();
 
-		if (file_exists($theme_config_path)) {
+		if (file_exists($theme_config_path) && !$enable_default_style) {
 			$block_style_handle = 'solarplexus-style-custom';
 		}
 

--- a/admin/class-solarplexus-admin.php
+++ b/admin/class-solarplexus-admin.php
@@ -146,6 +146,13 @@ class Solarplexus_Admin {
 	}
 
 	public function register_block() {
+		$block_style_handle = 'solarplexus-style';
+		$theme_config_path = Solarplexus_Helpers::get_theme_config_path();
+
+		if (file_exists($theme_config_path)) {
+			$block_style_handle = 'solarplexus-style-custom';
+		}
+
 		foreach ($this->get_config() as $block_config) {
 			$block_type_id = Solarplexus_Helpers::get_block_type_id(
 				$block_config
@@ -171,7 +178,7 @@ class Solarplexus_Admin {
 			register_block_type("splx/{$block_type_id}", [
 				'attributes' => $attributes,
 				'editor_script' => 'solarplexus-script',
-				'style' => 'solarplexus-style',
+				'style' => $block_style_handle,
 				'render_callback' => function (
 					$block_attributes,
 					$content

--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -47,3 +47,13 @@ add_filter('splx_queryargs', function($args, $block_config, $block_attributes){
   return $args;
 }, 10, 3);
 ```
+
+## Enable default block styling
+
+By default the block styling by the plugin is disabled if you've added your own splx-config.json in your theme. If you'd like to enable it, you can do so by adding the following to your theme's `functions.php` file:
+
+```
+add_filter('splx_enable_default_style', function() {
+	return true;
+});
+```

--- a/includes/class-solarplexus-helpers.php
+++ b/includes/class-solarplexus-helpers.php
@@ -14,6 +14,10 @@ class Solarplexus_Helpers {
 	// Used to know which block we are in
 	private static $block_index = 0;
 
+	public static function get_theme_config_path() {
+		return get_stylesheet_directory() . (self::is_sage_10() ? '/resources' : '') . '/splx-config.json'; // NOTE: get_stylesheet_directory() returns the /resources path in Sage 10, but not in Sage 9
+	}
+
 	public static function retrieve_block_configs() {
 		// Allow config via PHP
 		$config_data = apply_filters('splx_config', []);
@@ -22,7 +26,7 @@ class Solarplexus_Helpers {
 			$config_path = SPLX_PLUGIN_PATH . 'splx-config.json';
 		}
 
-		$theme_config_path = get_stylesheet_directory() . (self::is_sage_10() ? '/resources' : '') . '/splx-config.json'; // NOTE: get_stylesheet_directory() returns the /resources path in Sage 10, but not in Sage 9
+		$theme_config_path = self::get_theme_config_path();
 
 		// Override with custom config from theme
 		if (file_exists($theme_config_path)) {

--- a/includes/class-solarplexus.php
+++ b/includes/class-solarplexus.php
@@ -150,7 +150,7 @@ class Solarplexus {
 			'enqueue_styles'
 		);
 		$this->loader->add_action(
-			'init',
+			'admin_enqueue_scripts',
 			$plugin_admin,
 			'register_scripts',
 			11

--- a/includes/class-solarplexus.php
+++ b/includes/class-solarplexus.php
@@ -61,6 +61,7 @@ class Solarplexus {
 		$this->load_dependencies();
 		$this->set_locale();
 		$this->define_admin_hooks();
+		$this->define_public_hooks();
 	}
 
 	/**
@@ -109,6 +110,12 @@ class Solarplexus {
 		require_once plugin_dir_path(dirname(__FILE__)) .
 			'admin/class-solarplexus-admin.php';
 
+		/**
+		 * The class responsible for defining all actions that occur in the public area.
+		 */
+		require_once plugin_dir_path(dirname(__FILE__)) .
+			'public/class-solarplexus-public.php';
+
 		$this->loader = new Solarplexus_Loader();
 	}
 
@@ -156,6 +163,26 @@ class Solarplexus {
 			11
 		);
 		$this->loader->add_action('init', $plugin_admin, 'register_block', 11);
+	}
+
+	/**
+	 * Register all of the hooks related to the admin area functionality
+	 * of the plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 */
+	private function define_public_hooks() {
+		$plugin_public = new Solarplexus_Public(
+			$this->get_plugin_name(),
+			$this->get_version()
+		);
+
+		$this->loader->add_action(
+			'wp_enqueue_scripts',
+			$plugin_public,
+			'register_style'
+		);
 	}
 
 	/**

--- a/public/class-solarplexus-public.php
+++ b/public/class-solarplexus-public.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * The public specific functionality of the plugin.
+ *
+ * @link       https://aventyret.com
+ * @since      1.0.0
+ *
+ * @package    Solarplexus
+ * @subpackage Solarplexus/public
+ */
+class Solarplexus_Public {
+	/**
+	 * The ID of this plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 * @var      string    $plugin_name    The ID of this plugin.
+	 */
+	private $plugin_name;
+
+	/**
+	 * The version of this plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 * @var      string    $version    The current version of this plugin.
+	 */
+	private $version;
+
+	private $config;
+
+	/**
+	 * Initialize the class and set its properties.
+	 *
+	 * @since    1.0.0
+	 * @param      string    $plugin_name       The name of this plugin.
+	 * @param      string    $version    The version of this plugin.
+	 */
+	public function __construct($plugin_name, $version) {
+		$this->plugin_name = $plugin_name;
+		$this->version = $version;
+	}
+
+	/**
+	 * Register the stylesheets for the public area.
+	 *
+	 * @since    1.0.0
+	 */
+	public function register_style() {
+		wp_register_style(
+			'solarplexus-style',
+			SPLX_PLUGIN_DIR_URL . 'build/index.css',
+			[],
+			filemtime(SPLX_PLUGIN_PATH . 'build/index.css')
+		);
+	}
+}


### PR DESCRIPTION
Closes #82.

- [x] Separate admin and public area styles and scripts.
- [x] Disable plugin styles when config is found in theme.
- [x] Add filter to enable plugin styles.
- [x] Update docs.