### PR TITLE
Ignore sticky posts and fix js error in editor

### DIFF
--- a/includes/class-solarplexus-helpers.php
+++ b/includes/class-solarplexus-helpers.php
@@ -122,6 +122,7 @@ class Solarplexus_Helpers {
 		// Query posts
 		$args = [
 			'post_status' => 'publish',
+			'ignore_sticky_posts' => true,
 		];
 
 		$current_post_id = get_the_ID();

--- a/src/components/dynamic-inspector-controls/dynamic-inspector-controls.js
+++ b/src/components/dynamic-inspector-controls/dynamic-inspector-controls.js
@@ -250,7 +250,7 @@ const DynamicInspectorControls = ({ attributes, setAttributes, config }) => {
 					className="splx-panel splx-panel--no-scroll"
 					title={__('Filter', 'splx')}
 				>
-					{availableTaxonomiesWithTerms.map((taxonomyWithTerms) => {
+					{(availableTaxonomiesWithTerms || []).map((taxonomyWithTerms) => {
 						return (
 							<FormTokenField
 								key={taxonomyWithTerms.slug}


### PR DESCRIPTION
Closes #87 
Closes #92 

For now we always ignore sticky posts in solarplexus blocks.