### PR TITLE
Add pagination next url permalink filter

### DIFF
--- a/includes/class-solarplexus-helpers.php
+++ b/includes/class-solarplexus-helpers.php
@@ -338,12 +338,18 @@ class Solarplexus_Helpers {
 		// Is this block paginated?
 		$pagination = false;
 		if ($has_pagination) {
+			$permalink = get_permalink();
+			$next_url_permalink = apply_filters(
+				'splx_pagination_next_url_permalink',
+				$permalink
+			);
+
 			$pagination = [
 				'page' => self::block_page($block_attributes),
 				'max_num_pages' => $query->max_num_pages,
 				'next_url' =>
 					self::block_page($block_attributes) < $query->max_num_pages
-						? rtrim(get_permalink(), '/') .
+						? rtrim($next_url_permalink, '/') .
 							'?' .
 							self::block_page_query_parameter(
 								$block_attributes


### PR DESCRIPTION
Closes #120 

Example usage:

```
/**
 * Return the URL of the current term if the page is an archive page.
 */
add_filter('splx_pagination_next_url_permalink', function($permalink) {
    $result = $permalink;

    if (is_archive()) {
        $term = get_queried_object();

        if ($term) {
            $term_permalink = get_term_link($term);

            if ($term_permalink) {
                $result = $term_permalink;
            }
        }
    }

    return $result;
}, 10, 1);
```