### PR TITLE
131: Use non-dynamic query vars for block pagination

### DIFF
--- a/includes/class-solarplexus-helpers.php
+++ b/includes/class-solarplexus-helpers.php
@@ -777,14 +777,18 @@ class Solarplexus_Helpers {
 	}
 
 	public static function block_page_query_parameter($block_attributes) {
-		return 'block_' . $block_attributes['blockUid'] . '_page';
+		return 'splx_block_uid=' . $block_attributes['blockUid'] . '&splx_block_page';
 	}
 
 	public static function block_page($block_attributes) {
-		$page = get_query_var(
-			self::block_page_query_parameter($block_attributes)
-		);
-		if (!$page) {
+		$block_id = get_query_var('splx_block_uid');
+		$page = get_query_var('splx_block_page');
+
+		if (
+			empty($page) ||
+			empty($block_attributes['blockUid']) ||
+			$block_id !== $block_attributes['blockUid']
+		) {
 			return 1;
 		}
 		return (int) $page;

--- a/includes/class-solarplexus.php
+++ b/includes/class-solarplexus.php
@@ -194,6 +194,12 @@ class Solarplexus {
 			$plugin_public,
 			'add_query_vars'
 		);
+
+		$this->loader->add_action(
+			'pre_get_posts',
+			$plugin_public,
+			'alter_pre_get_posts'
+		);
 	}
 
 	/**

--- a/includes/class-solarplexus.php
+++ b/includes/class-solarplexus.php
@@ -188,6 +188,12 @@ class Solarplexus {
 			$plugin_public,
 			'register_style'
 		);
+
+		$this->loader->add_action(
+			'query_vars',
+			$plugin_public,
+			'add_query_vars'
+		);
 	}
 
 	/**

--- a/public/class-solarplexus-public.php
+++ b/public/class-solarplexus-public.php
@@ -105,9 +105,9 @@ class Solarplexus_Public {
 		if (
 			$query->is_main_query() &&
 			$query->is_home() &&
-			(get_option('show_on_front') === 'page') &&
 			get_query_var('splx_block_uid') &&
-			get_query_var('splx_block_page')
+			get_query_var('splx_block_page') &&
+			(get_option('show_on_front') === 'page')
 		) {
 			$query->is_home = false;
 			$query->is_page = true;

--- a/public/class-solarplexus-public.php
+++ b/public/class-solarplexus-public.php
@@ -84,4 +84,14 @@ class Solarplexus_Public {
 			);
 		}
 	}
+
+	/**
+	 * Add query vars used in block pagination.
+	 */
+	public function add_query_vars($vars) {
+		$vars[] = 'splx_block_page';
+		$vars[] = 'splx_block_uid';
+
+		return $vars;
+	}
 }

--- a/public/class-solarplexus-public.php
+++ b/public/class-solarplexus-public.php
@@ -94,4 +94,25 @@ class Solarplexus_Public {
 
 		return $vars;
 	}
+
+	/**
+	 * Alter the main query for block pagination.
+	 *
+	 * This is needed to ensure the correct pages is displayed
+	 * when custom query vars are present on the front page.
+	 */
+	public function alter_pre_get_posts($query) {
+		if (
+			$query->is_main_query() &&
+			$query->is_home() &&
+			(get_option('show_on_front') === 'page') &&
+			get_query_var('splx_block_uid') &&
+			get_query_var('splx_block_page')
+		) {
+			$query->is_home = false;
+			$query->is_page = true;
+			$query->is_singular = true;
+			$query->set('page_id', get_option('page_on_front'));
+		}
+	}
 }


### PR DESCRIPTION
Closes #131 

Updated block pagination to use 'splx_block_page' and 'splx_block_uid' as query variables instead of dynamic parameter names. Registered these query vars in the public class to ensure they are recognized by WordPress. This change improves consistency and reliability in block pagination handling.